### PR TITLE
Add Flask backend and README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,64 @@
-# Farm-gps
+# Farm GPS
+
+This repository contains a minimal example for displaying avocado farm locations in Queensland.
+It includes a static HTML map and a simple Flask backend with a SQLite database.
+
+## Requirements
+
+- Python 3.9+
+- `pip` for installing Python packages
+
+Install dependencies from `requirements.txt`:
+
+```bash
+pip install -r requirements.txt
+```
+
+This installs Flask, Flask-SQLAlchemy and other utilities used by the project.
+
+## Running the server
+
+Start the Flask server from the project root:
+
+```bash
+python server.py
+```
+
+The application will create a local SQLite database file `farms.db` if it does not already exist.
+By default the server listens on `http://localhost:5000/`.
+Opening that URL in a browser will display `avocadoFarms.html`.
+
+You can also open the HTML page directly without running the server by opening
+`avocadoFarms.html` in a web browser, but the API to store farms will only be
+available when the server is running.
+
+## Example API usage
+
+List all stored farms:
+
+```bash
+curl http://localhost:5000/farms
+```
+
+Add a new farm record:
+
+```bash
+curl -X POST http://localhost:5000/farms \
+  -H "Content-Type: application/json" \
+  -d '{
+        "name": "Example Farm",
+        "lat": -27.0,
+        "lng": 153.0,
+        "area": 50,
+        "region": "Test Region",
+        "established": 2020
+      }'
+```
+
+When a farm is added successfully, the API returns the new record ID.
+
+## Development notes
+
+The backend logic for fetching real agricultural data is in `backend.py` and is
+separate from the Flask server in `server.py`. Currently `backend.py` only
+contains example code and does not communicate with the API.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+Flask
+Flask-SQLAlchemy
+requests
+pandas
+geopy
+folium


### PR DESCRIPTION
## Summary
- add a Flask server with SQLite storage for farms
- provide requirements.txt listing dependencies
- expand README with setup, running instructions and API usage

## Testing
- `python -m py_compile server.py backend.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_68464463b760832baac7811671b507c2