### PR TITLE
Fix API path and search support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,19 @@ available when the server is running.
 List all stored farms:
 
 ```bash
-curl http://localhost:5000/farms
+curl http://localhost:5000/api/farms
+```
+
+Search farms by name or region:
+
+```bash
+curl "http://localhost:5000/api/farms?search=coast"
 ```
 
 Add a new farm record:
 
 ```bash
-curl -X POST http://localhost:5000/farms \
+curl -X POST http://localhost:5000/api/farms \
   -H "Content-Type: application/json" \
   -d '{
         "name": "Example Farm",


### PR DESCRIPTION
## Summary
- align backend endpoints to `/api/farms`
- support searching farms by name or region
- document new API paths and query usage

## Testing
- `python -m py_compile server.py backend.py`

------
https://chatgpt.com/codex/tasks/task_e_684640645e38832b8d1446d34b0fb674